### PR TITLE
feat: set default values for optional parameters in UploadSupportBundle

### DIFF
--- a/src/Atc.Azure.IoT/Models/IIoTHubModuleServiceModels.cs
+++ b/src/Atc.Azure.IoT/Models/IIoTHubModuleServiceModels.cs
@@ -32,9 +32,9 @@ public record RestartModuleRequest(
 /// Default: <see langword="false" />.</param>
 public record UploadSupportBundleRequest(
     [property: JsonPropertyName("sasUrl")] Uri SasUrl,
-    [property: JsonPropertyName("since")] string? Since,
-    [property: JsonPropertyName("until")] string? Until,
-    [property: JsonPropertyName("edgeRuntimeOnly")] bool? EdgeRuntimeOnly)
+    [property: JsonPropertyName("since")] string? Since = null,
+    [property: JsonPropertyName("until")] string? Until = null,
+    [property: JsonPropertyName("edgeRuntimeOnly")] bool EdgeRuntimeOnly = false)
     : SchemaVersion10;
 
 public record GetTaskStatusRequest(


### PR DESCRIPTION
In my previous PR, #17,  I didn't fully think the request object through.

With the current version, we have to do something like this
```
var result = await ioTHubService.UploadSupportBundle(
            deviceId,
            new UploadSupportBundleRequest(
                containerSasUrl,
                Since: null,
                Until: null,
                EdgeRuntimeOnly: null));
```

With my proposed change, we can write less code, if we don't care about the nullable parameters
```
var result = await ioTHubService.UploadSupportBundle(
            deviceId,
            new UploadSupportBundleRequest(containerSasUrl);
```